### PR TITLE
Fixes Readme and docstring to wrap the boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ component:
 (defn root []
   (assert false "Oops"))
 
-(r/render-component (fn [] [error-boundary [root]])
+(r/render-component [(fn [] [error-boundary [root]])]
                     (.. js/document (querySelector \"#container\")))
 ```
 

--- a/src/recalcitrant/core.cljs
+++ b/src/recalcitrant/core.cljs
@@ -88,7 +88,7 @@
   (ns my-ns
     (:require [error-boundary.error-boundary :refer [error-boundary]]))
 
-  (r/render-component (fn [] [error-boundary [root]])
+  (r/render-component [(fn [] [error-boundary [root]])]
                       (.. js/document (querySelector \"#container\")))
 
   Note that this relies on the undocumented unstable_handleError API introduced


### PR DESCRIPTION
Boundary is not effective unless wrapped in []
I don't know why.
